### PR TITLE
Remove redundant Jekyll gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 # gem "rails"
-gem "jekyll"
 gem 'github-pages'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -256,7 +256,6 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
-  jekyll
 
 BUNDLED WITH
    2.3.19


### PR DESCRIPTION
## Summary
- remove direct `jekyll` gem to rely on `github-pages`

## Testing
- `bundle install` *(fails: nokogiri-1.13.8 requires Ruby < 3.2)*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c839cca0832fb78acdd3434a00d9