### PR TITLE
Fix HTML entity in certifications title

### DIFF
--- a/_data/en.yml
+++ b/_data/en.yml
@@ -146,7 +146,7 @@ experiences:
           on projects and supervised their research endeavors.
           
 certifications:
-      title: Certifications &amp Courses
+      title: Certifications &amp; Courses
       list:
         - name: Azure Data Scientist
           start: 2021


### PR DESCRIPTION
## Summary
- fix unescaped ampersand in certifications title on English data file

## Testing
- `bundle install` *(fails: nokogiri-1.13.8 requires ruby < 3.2.dev)*
- `bundle exec jekyll build` *(fails: jekyll command not found; run `bundle install`)*

------
https://chatgpt.com/codex/tasks/task_e_68a0dd9c9898832f99750356a9afb703