### PR TITLE
Use lowercase comment in about include

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -7,4 +7,4 @@
      <li><a class="github-button" href="https://github.com/lerker" data-icon="octicon-star" data-show-count="true" aria-label="Star sharu725/online-cv on GitHub">Star</a>
      <script async defer src="https://buttons.github.io/buttons.js"></script>
   </ul>
-</div><!--//About-->
+</div><!--//about-->


### PR DESCRIPTION
## Summary
- Use lowercase form `<!--//about-->` in about include to match comment style

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: nokogiri-1.13.8-x86_64-linux requires ruby < 3.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a0df7d72cc832f8a232b227c6ebdf2