### PR TITLE
Add link check workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,18 @@
+name: Link Check
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+      - name: Install dependencies
+        run: bundle install --path vendor/bundle
+      - name: Build site
+        run: bundle exec jekyll build
+      - name: Check links
+        run: bundle exec htmlproofer ./_site


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build the site and run htmlproofer for link checking

## Testing
- `bundle install --path vendor/bundle` *(fails: nokogiri requires ruby < 3.2)*
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle exec htmlproofer ./_site` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e03aa928832fbbafb7d7c40b1407