### PR TITLE
chore: update Jekyll image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: "2"
 services:
   jekyll:
-      image: jekyll/jekyll:3.8
-      command: jekyll serve --force_polling
+      image: jekyll/jekyll:3.9
+      command: bundle exec jekyll serve --force_polling
       ports:
           - 4000:4000
       volumes:


### PR DESCRIPTION
## Summary
- use GitHub Pages compatible Jekyll image 3.9
- run server via `bundle exec`

## Testing
- `docker-compose config`
- `docker-compose up -d` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e640f4ec832fbdc4c86a387ff4c5