### PR TITLE
Specify Ruby version for GitHub Pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+ruby "3.3.4"
 
 # gem "rails"
 gem 'github-pages'


### PR DESCRIPTION
## Summary
- declare Ruby 3.3.4 in Gemfile to match GitHub Pages

## Testing
- `bundle update --bundler` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.4)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e6453bfc832f88a716fcbfc7879d