### PR TITLE
Fix certification loop variable naming

### DIFF
--- a/_includes/certifications.html
+++ b/_includes/certifications.html
@@ -8,32 +8,32 @@
     {{ certifications.title }}
   </h2>
 
-  {% for certifications in certifications.list %}
+  {% for certification in certifications.list %}
   <div class="item">
     <div class="meta">
       <div class="upper-row">
         <h3 class="cert-title">
-          <i class="fas fa-caret-right"></i> {{ certifications.name }}
+          <i class="fas fa-caret-right"></i> {{ certification.name }}
         </h3>
         <div class="time">
-          {{ certifications.start }} {% if certifications.end %} - {{
-          certifications.end }} {% endif %}
+          {{ certification.start }} {% if certification.end %} - {{
+          certification.end }} {% endif %}
         </div>
       </div>
       <!--//upper-row-->
 
       <div class="second-upper-row">
         <div class="cert-org">
-          {{ certifications.organization }} {% if certifications.credentialid %}
-          ({{ certifications.credentialid }}) {% endif %}
+          {{ certification.organization }} {% if certification.credentialid %}
+          ({{ certification.credentialid }}) {% endif %}
         </div>
-        {% if certifications.credentialurl %}
+        {% if certification.credentialurl %}
         <div class="cert-url">
           <a
-            href="//{{ certifications.credentialurl }}"
+            href="//{{ certification.credentialurl }}"
             target="_blank"
             rel="noreferrer nofollow noopener"
-            >{{ certifications.credentialname }}</a
+            >{{ certification.credentialname }}</a
           >
         </div>
         {% endif %}
@@ -41,7 +41,7 @@
     </div>
     <!--//meta-->
 
-    <div class="details">{{ certifications.details | markdownify }}</div>
+    <div class="details">{{ certification.details | markdownify }}</div>
   </div>
   <!--//item-->
   {% endfor %}


### PR DESCRIPTION
## Summary
- rename certification loop variable to avoid shadowing

## Testing
- `bundle install` *(fails: nokogiri requires ruby < 3.2.dev)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e650ef78832f8287fd5912d29b37