### PR TITLE
Add jekyll-compress-html plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 # gem "rails"
 gem 'github-pages'
+gem "jekyll-compress-html", git: "https://github.com/penibelst/jekyll-compress-html"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,8 @@ sass:
   style: compressed # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#output_style
 
 # Build settings
-compress-site: yes
+plugins:
+  - jekyll-compress-html
 
 encoding: "utf-8"
 compress_html: # - http://jch.penibelst.de/


### PR DESCRIPTION
## Summary
- add jekyll-compress-html plugin
- enable jekyll-compress-html in site config

## Testing
- `bundle install` *(fails: Could not find gem 'jekyll-compress-html' in https://github.com/penibelst/jekyll-compress-html)*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e649e644832fb883b6b01c5bec77