### PR TITLE
chore: update ruby to 3.3.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1'
+          ruby-version: '3.3.4'
           bundler-cache: true
       - name: Install dependencies
         run: bundle install --path vendor/bundle

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.4'
+          bundler-cache: true
       - name: Install dependencies
         run: bundle install --path vendor/bundle
       - name: Build site

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,11 @@ ruby "3.3.4"
 
 # gem "rails"
 gem 'github-pages'
-gem "jekyll-compress-html", git: "https://github.com/penibelst/jekyll-compress-html"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+group :development do
+  gem 'html-proofer'
+end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     activesupport (6.0.5.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -9,6 +10,14 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    afm (1.0.0)
+    async (2.27.3)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.15)
+    bigdecimal (3.2.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -16,6 +25,10 @@ GEM
     colorator (1.1.0)
     commonmarker (0.23.5)
     concurrent-ruby (1.1.10)
+    console (1.33.0)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     dnsruby (1.61.9)
       simpleidn (~> 0.1)
     em-websocket (0.5.3)
@@ -30,6 +43,10 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.0)
     ffi (1.15.5)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (227)
@@ -83,12 +100,23 @@ GEM
       octokit (~> 4.0)
       public_suffix (>= 3.0, < 5.0)
       typhoeus (~> 1.3)
+    hashery (2.1.2)
     html-pipeline (2.14.2)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-proofer (5.0.10)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-event (1.12.1)
     jekyll (3.9.2)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -197,6 +225,7 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
+    json (2.13.2)
     kramdown (2.3.2)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -206,25 +235,36 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
+    metrics (0.13.0)
+    mini_portile2 (2.8.9)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.16.2)
-    nokogiri (1.13.8-x86_64-linux)
+    nokogiri (1.13.8)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pdf-reader (2.15.0)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     public_suffix (4.0.7)
     racc (1.6.0)
+    rainbow (3.1.1)
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
     rouge (3.26.0)
+    ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
@@ -241,6 +281,9 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
+    traces (0.17.0)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.10)
@@ -249,6 +292,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    yell (2.2.2)
     zeitwerk (2.6.0)
 
 PLATFORMS
@@ -256,6 +300,10 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  html-proofer
+
+RUBY VERSION
+   ruby 3.3.4p94
 
 BUNDLED WITH
    2.3.19


### PR DESCRIPTION
## Summary
- use Ruby 3.3.4 in build and link-check workflows
- add html-proofer dependency for link checking
- drop obsolete jekyll-compress-html gem

## Testing
- `bundle exec jekyll build` *(fails: undefined method `[]' for nil)*
- `bundle exec htmlproofer ./_site` *(fails: ./_site does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e8c6d308832fab7a4aa8b69734f5