### PR TITLE
Add jekyll-compress-html gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ ruby "3.3.4"
 # gem "rails"
 gem 'github-pages'
 
+gem 'jekyll-compress-html'
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 


### PR DESCRIPTION
## Summary
- add the jekyll-compress-html plugin to the Gemfile for HTML compression

## Testing
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.4)*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a0edcf63ac832f8002c6afc3a275cd