### PR TITLE
Replace broken 3rd Wave Media links

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -17,5 +17,5 @@ jobs:
         run: bundle install --path vendor/bundle
       - name: Build site
         run: bundle exec jekyll build
-      - name: Check links
-        run: bundle exec htmlproofer ./_site
+        - name: Check links
+          run: bundle exec htmlproofer ./_site --url-ignore https://themes.3rdwavemedia.com

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 </a>
 
 # Orbit
-> This theme is designed by Xiaoying Riley at [3rd Wave Media](http://themes.3rdwavemedia.com/).
-> Visit her [website](http://themes.3rdwavemedia.com/) for more themes.
+> This theme is designed by Xiaoying Riley at [3rd Wave Media](https://github.com/xriley).
+> Visit her [GitHub profile](https://github.com/xriley) for more themes.
 
 This is a fork. 
 
-You can also visit: 
- - https://themes.3rdwavemedia.com/
+You can also visit:
+ - https://github.com/xriley
  - https://github.com/RobertDeRose/pillar-resume-template

--- a/_data/en.yml
+++ b/_data/en.yml
@@ -413,6 +413,6 @@ skills:
 footer: >
     <p class="credit">
       Designed with <i class="fas fa-heart"></i> by
-      <a href="http://themes.3rdwavemedia.com" target="_blank" rel="nofollow">Xiaoying Riley</a>
+      <a href="https://github.com/xriley" target="_blank" rel="nofollow">Xiaoying Riley</a>
       and adapted by <span class="highlight">Nelson Ponzoni</span>
     </p>

--- a/_data/es.yml
+++ b/_data/es.yml
@@ -326,6 +326,6 @@ skills:
 footer: >
   <p class="credit">
     Diseñado con <i class="fas fa-heart"></i> por
-    <a href="http://themes.3rdwavemedia.com" target="_blank" rel="nofollow">Xiaoying Riley</a>
+    <a href="https://github.com/xriley" target="_blank" rel="nofollow">Xiaoying Riley</a>
     y adaptado por <span class="highlight">Nelson Ponzoni</span>
   </p>


### PR DESCRIPTION
## Summary
- replace defunct `themes.3rdwavemedia.com` links with `https://github.com/xriley`
- ignore `themes.3rdwavemedia.com` in link-check workflow

## Testing
- ⚠️ `bundle install --path vendor/bundle` *(failed: io-event-1.12.1 requires ruby version >= 3.2.6)*

------
https://chatgpt.com/codex/tasks/task_e_68a0edd46d10832fa3914e9e3521f389